### PR TITLE
Adopt Current Session in Storefront authentication and guards

### DIFF
--- a/backend/src/features/core/application/services/createCurrentSessionProvider.ts
+++ b/backend/src/features/core/application/services/createCurrentSessionProvider.ts
@@ -1,0 +1,16 @@
+import type { ICurrentSessionIdentityResolver, ICookieStore } from './CurrentSessionProvider';
+import { CurrentSessionProvider } from './CurrentSessionProvider';
+import { JwtSessionManager } from '../../infrastructure/auth/JwtSessionManager';
+
+/**
+ * Creates the shared Current Session module with FindEg's signed-cookie policy.
+ *
+ * Portal applications provide only request-cookie access and identity resolution;
+ * the JWT implementation remains an internal core detail.
+ */
+export function createCurrentSessionProvider(
+  cookieStore: ICookieStore,
+  identityResolver: ICurrentSessionIdentityResolver,
+): CurrentSessionProvider {
+  return new CurrentSessionProvider(cookieStore, identityResolver, new JwtSessionManager());
+}

--- a/backend/src/features/core/index.ts
+++ b/backend/src/features/core/index.ts
@@ -37,6 +37,7 @@ export {
   type ICookieStore,
   type ICurrentSessionIdentityResolver,
 } from './application/services/CurrentSessionProvider';
+export { createCurrentSessionProvider } from './application/services/createCurrentSessionProvider';
 export { CookieSessionProvider } from './infrastructure/auth/CookieSessionProvider';
 
 // ========================================

--- a/backend/src/features/identity/application/services/AuthService.ts
+++ b/backend/src/features/identity/application/services/AuthService.ts
@@ -5,7 +5,7 @@
  * for user lookup and authorization resolution.
  *
  * Performs password verification but does NOT create sessions.
- * Session creation is app-layer responsibility (done via CookieSessionProvider in app-layer).
+ * Session creation is app-layer responsibility (through the shared Current Session module).
  *
  * Uses bcryptjs for password verification.
  */

--- a/frontend/storefront/src/app/[locale]/(auth)/login/_components/LoginForm.tsx
+++ b/frontend/storefront/src/app/[locale]/(auth)/login/_components/LoginForm.tsx
@@ -10,10 +10,6 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { Input } from '@findeg/ui';
 import { Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-const persistSessionToken = (token: string) => {
-  /* internal handler mapped later */
-};
-
 const formSchema = z.object({
   email: z.string().email({
     message: 'Please enter a valid email address.',
@@ -25,9 +21,6 @@ const formSchema = z.object({
 
 interface LoginResponseBody {
   success?: boolean;
-  data?: {
-    token?: string;
-  };
   error?: {
     message?: string;
   };
@@ -76,9 +69,6 @@ export function LoginForm() {
         return;
       }
 
-      if (json?.data?.token) {
-        persistSessionToken(json.data.token);
-      }
       router.push('/my-account');
       router.refresh();
     } finally {

--- a/frontend/storefront/src/app/[locale]/(auth)/registration/_components/RegistrationForm.tsx
+++ b/frontend/storefront/src/app/[locale]/(auth)/registration/_components/RegistrationForm.tsx
@@ -10,10 +10,6 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '
 import { Input } from '@findeg/ui';
 import { Loader2 } from 'lucide-react';
 import { useTranslations } from 'next-intl';
-const persistSessionToken = (token: string) => {
-  /* internal handler mapped later */
-};
-
 const formSchema = z
   .object({
     name: z.string().min(2, {
@@ -34,9 +30,6 @@ const formSchema = z
 
 interface RegisterResponseBody {
   success?: boolean;
-  data?: {
-    token?: string;
-  };
   error?: {
     message?: string;
   };
@@ -108,9 +101,6 @@ export function RegistrationForm() {
         return;
       }
 
-      if (json?.data?.token) {
-        persistSessionToken(json.data.token);
-      }
       router.push('/my-account');
       router.refresh();
     } finally {

--- a/frontend/storefront/src/app/api/v1/auth/login/route.ts
+++ b/frontend/storefront/src/app/api/v1/auth/login/route.ts
@@ -1,0 +1,44 @@
+import { createIdentityServices } from '@findeg/backend/features/identity';
+import { NextResponse } from 'next/server';
+import { establishSession } from '@lib/session';
+
+interface LoginBody {
+  email?: unknown;
+  password?: unknown;
+}
+
+/** Authenticates a Storefront User and establishes the HTTP-only Current Session. */
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: LoginBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: { message: 'Invalid request body' } }, { status: 400 });
+  }
+
+  if (typeof body.email !== 'string' || typeof body.password !== 'string') {
+    return NextResponse.json(
+      { success: false, error: { message: 'Email and password are required' } },
+      { status: 400 },
+    );
+  }
+
+  const { auth } = createIdentityServices();
+  const result = await auth.login(body.email.trim(), body.password);
+  if (!result.success || !result.user) {
+    return NextResponse.json(
+      { success: false, error: { message: result.error ?? 'Invalid credentials' } },
+      { status: 401 },
+    );
+  }
+
+  const session = await establishSession(result.user.id);
+  if (!session) {
+    return NextResponse.json(
+      { success: false, error: { message: 'Account is not active' } },
+      { status: 401 },
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/frontend/storefront/src/app/api/v1/auth/register/route.ts
+++ b/frontend/storefront/src/app/api/v1/auth/register/route.ts
@@ -1,0 +1,41 @@
+import { RegisterInputSchema } from '@findeg/backend/features/identity';
+import { createIdentityServices } from '@findeg/backend/features/identity';
+import { NextResponse } from 'next/server';
+import { establishSession } from '@lib/session';
+
+/** Registers a customer and establishes the HTTP-only Current Session. */
+export async function POST(request: Request): Promise<NextResponse> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ success: false, error: { message: 'Invalid request body' } }, { status: 400 });
+  }
+
+  const input = RegisterInputSchema.safeParse(body);
+  if (!input.success) {
+    return NextResponse.json(
+      { success: false, error: { message: input.error.issues[0]?.message ?? 'Invalid registration details' } },
+      { status: 400 },
+    );
+  }
+
+  const { auth } = createIdentityServices();
+  const result = await auth.register(input.data);
+  if (!result.success || !result.user) {
+    return NextResponse.json(
+      { success: false, error: { message: result.error ?? 'Registration failed' } },
+      { status: 400 },
+    );
+  }
+
+  const session = await establishSession(result.user.id);
+  if (!session) {
+    return NextResponse.json(
+      { success: false, error: { message: 'Account is not active' } },
+      { status: 401 },
+    );
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/frontend/storefront/src/data/auth/queries.ts
+++ b/frontend/storefront/src/data/auth/queries.ts
@@ -1,21 +1,15 @@
-"use cache";
-
-import { cacheLife, cacheTag } from "next/cache";
 import { getSession } from "@lib/session";
 import type { SessionPayload } from "@findeg/backend/features/core";
 
 /**
  * Cached session query for server components
  *
- * Uses Next.js 16 Cache Components to avoid uncached data access
- * during prerendering/build phase. Critical for auth-dependent pages.
+ * Current Session resolution is request-only. `getSession` applies request-level
+ * memoization while allowing Next.js request APIs such as `cookies()`.
  *
  * @returns Session payload or null if not authenticated
  */
 export async function getCachedSession(): Promise<SessionPayload | null> {
-    cacheLife("hours");
-    cacheTag("session");
-
     try {
         return await getSession();
     } catch (error) {

--- a/frontend/storefront/src/lib/session.ts
+++ b/frontend/storefront/src/lib/session.ts
@@ -1,6 +1,11 @@
 import type { SessionPayload } from '@findeg/backend/features/core';
-import { CookieSessionProvider, type ICookieStore } from '@findeg/backend/features/core';
+import {
+  createCurrentSessionProvider,
+  type ICookieStore,
+} from '@findeg/backend/features/core';
+import { CurrentSessionIdentityResolver } from '@findeg/backend/features/identity';
 import { cookies } from 'next/headers';
+import { cache } from 'react';
 
 /**
  * Storefront Session Helpers
@@ -8,8 +13,8 @@ import { cookies } from 'next/headers';
  * Extracts session from Next.js cookies for customer authentication.
  * Used by Storefront Server Components and Server Actions.
  *
- * CookieSessionProvider is instantiated with Next.js cookie store injected.
- * This allows backend to remain framework-agnostic while apps handle framework integration.
+ * The portal supplies only request-cookie access. The shared Current Session
+ * module owns signing, identity validation, renewal, and invalidation.
  *
  * @example
  * const session = await getSession();
@@ -37,41 +42,50 @@ async function nextCookiesToStore(): Promise<ICookieStore> {
   };
 }
 
+async function currentSession() {
+  const cookieStore = await nextCookiesToStore();
+  return createCurrentSessionProvider(cookieStore, new CurrentSessionIdentityResolver());
+}
+
+// React cache is scoped to the active server request. Unlike Next's "use cache",
+// it may read request cookies and never shares an identity between requests.
+const getRequestSession = cache(async (): Promise<SessionPayload | null> => {
+  const provider = await currentSession();
+  return provider.getSession();
+});
+
 /**
  * Extracts the current customer session from cookies.
  * Returns null if no valid session cookie exists.
  *
- * Uses injected CookieSessionProvider with Next.js cookies.
+ * Resolves the request's Current Session and invalidates malformed or inactive identities.
  *
  * @returns Session payload with customer ID, or null if not authenticated
  */
 export async function getSession(): Promise<SessionPayload | null> {
   try {
-    const cookieStore = await nextCookiesToStore();
-    const provider = new CookieSessionProvider(cookieStore);
-    return await provider.getSession();
+    return await getRequestSession();
   } catch {
     return null;
   }
 }
 
 /**
- * Creates a new customer session with the given payload
+ * Establishes a Current Session from the authoritative identity. Call this only
+ * from server-side authentication or profile flows; callers never supply grants.
  *
- * @param payload - Session data to store
+ * @param userId - Authenticated User identifier
  */
-export async function createSession(payload: SessionPayload): Promise<void> {
-  const cookieStore = await nextCookiesToStore();
-  const provider = new CookieSessionProvider(cookieStore);
-  await provider.createSession(payload);
+export async function establishSession(userId: number): Promise<SessionPayload | null> {
+  const provider = await currentSession();
+  return provider.establishSession(userId);
 }
 
 /**
  * Deletes the current customer session
  */
 export async function deleteSession(): Promise<void> {
-  const cookieStore = await nextCookiesToStore();
-  const provider = new CookieSessionProvider(cookieStore);
+  const provider = await currentSession();
   await provider.deleteSession();
 }
 


### PR DESCRIPTION
## Progress on #19

- replace Storefront direct CookieSessionProvider use with the shared Current Session seam
- establish the HTTP-only Current Session in server-side login and registration routes
- remove the browser token persistence placeholder
- replace the cross-request session cache with request-scoped memoization

## Validation

- Storefront type-check passed
- Backend test suite passed: 119 tests

## Follow-up

Portal-level login, routing, refresh, and Authorization Denial coverage remains before #19 can be closed.